### PR TITLE
Detect SMB type from AAPS treatments & setup bugfix

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -171,6 +171,7 @@ pub async fn handle_button(
 
             let success_response = CreateInteractionResponseMessage::new()
                 .embed(success_embed)
+                .components(vec![])
                 .ephemeral(true);
             interaction
                 .create_response(

--- a/src/utils/graph.rs
+++ b/src/utils/graph.rs
@@ -625,7 +625,8 @@ pub fn draw_graph(
 
         if treatment.is_insulin() {
             let insulin_amount = treatment.insulin.unwrap_or(0.0);
-            let is_microbolus = insulin_amount <= user_settings.microbolus_threshold;
+            let is_smb_type = treatment.type_.as_deref() == Some("SMB");
+            let is_microbolus = is_smb_type || insulin_amount <= user_settings.microbolus_threshold;
 
             if is_microbolus && !user_settings.display_microbolus {
                 continue;

--- a/src/utils/nightscout.rs
+++ b/src/utils/nightscout.rs
@@ -203,6 +203,8 @@ pub struct Treatment {
     pub date: Option<u64>,
     #[serde(default)]
     pub mills: Option<u64>,
+    #[serde(rename = "type", default)]
+    pub type_: Option<String>,
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
## SMB detection
AAPS uploads insulin treatments with a `type` field which indicates if it was a manual bolus or a SMB (issued by the algorithm). This should be more reliable than a threshold, since SMBs may (in some cases) exceed it and look like a manual bolus on the graph. It also simplifies setup for AAPS users, since they shouldn't need to adjust the threshold.

I was wondering: if the `type` field exists and says it's a manual bolus (type=`NORMAL`), should the bot ignore the threshold and treat it as manual? The type field doesn't override the threshold currently, but I feel like it should. I've done 0.5u manual boluses before and it may be confusing for manual boluses to appear as SMBs.

<details>
  <summary>JSON of both treatment types</summary>

```json
  {
    "_id": "68da4e7ac12760110f74462e",
    "app": "AAPS",
    "date": 1759136517000,
    "eventType": "Meal Bolus",
    "insulin": 1,
    "isBasalInsulin": false,
    "isReadOnly": false,
    "isValid": true,
    "pumpId": 20250929020157000,
    "pumpSerial": "[redacted]",
    "pumpType": "MEDTRONIC_522_722",
    "type": "NORMAL",
    "utcOffset": -420,
    "created_at": "2025-09-29T09:01:57.000Z",
    "identifier": "f4c29888-d524-53e7-aa6f-2b3ea708a55f",
    "srvModified": 1759137402896,
    "srvCreated": 1759137402896,
    "subject": "aaps",
    "carbs": null
  },
  {
    "_id": "68da4e7ac12760eb8974462d",
    "app": "AAPS",
    "date": 1759136471000,
    "eventType": "Correction Bolus",
    "insulin": 0.3,
    "isBasalInsulin": false,
    "isReadOnly": false,
    "isValid": true,
    "pumpId": 20250929020111000,
    "pumpSerial": "[redacted]",
    "pumpType": "MEDTRONIC_522_722",
    "type": "SMB",
    "utcOffset": -420,
    "created_at": "2025-09-29T09:01:11.000Z",
    "identifier": "8aaceeb1-8ffb-5337-96fe-af1ca36acb7b",
    "srvModified": 1759137402672,
    "srvCreated": 1759137402672,
    "subject": "aaps",
    "carbs": null
  }
```

</details>
  
  ## Setup bug
After choosing public/private, the buttons persist on the "Setup Complete" screen. Clicking them causes an error because the `handle_button` function can't extract the NS URL or token from the embed fields anymore. 

I solved this by clearing the buttons on the final response, since I figured they weren't meant to stay there.
<details>
  <summary>Image</summary>
	<img width="667" height="300" alt="Discord_2025-09-30_08-27-21_4BDiXnEciP" src="https://github.com/user-attachments/assets/26204261-a1a1-4d07-9f57-017d157e816a" />
</details>