### PR TITLE
fix erronous 'add-sticker' command in text string

### DIFF
--- a/src/commands/add_sticker.rs
+++ b/src/commands/add_sticker.rs
@@ -44,7 +44,7 @@ pub async fn run(
         crate::commands::error::run(
             context,
             interaction,
-            "You already have the maximum number of stickers (3). Use `/remove-sticker` to remove one first.",
+            "You already have the maximum number of stickers (3). Use `/sticker` to remove one first.",
         )
         .await?;
         return Ok(());


### PR DESCRIPTION
Adding a 4th sticker says to use /remove-sticker - but this command was renamed to /sticker