### PR TITLE
Remove unused environment variable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,7 +5,6 @@ DATABASE_URL=sqlite:///<PATH>
 # Rotating this value invalidates all stored tokens (users must re-run /setup).
 # Legacy name ENCRYPTION_SALT is still accepted for backward compatibility.
 ENCRYPTION_KEY=<32+ RANDOM SECRET CHARS>
-DISCORD_CLIENT_ID=<CLIENT ID>
 
 # Which baked-in emoji ID set to fall back to when the bot can't fetch its own
 # application emojis at startup: prod (default) or beta. The bot normally resolves


### PR DESCRIPTION
removes DISCORD_CLIENT_ID, it's useless