### PR TITLE
Sanitize Nightscout target ranges before calculations

### DIFF
--- a/crates/bot/src/commands/bg.rs
+++ b/crates/bot/src/commands/bg.rs
@@ -1,6 +1,7 @@
 use crate::data::{Context, Error};
 use crate::utils::duration_parser::parse_ago_duration;
 use crate::utils::emojis;
+use crate::utils::targets::resolve_profile_targets_mgdl;
 use crate::utils::theme_assets;
 use bonbon::prelude::*;
 use cinnamon::models::properties::PropertyType;
@@ -122,26 +123,13 @@ pub async fn bg(
             "bg/image raw data dump"
         );
 
-        let (target_low, target_high, is_mmol) = if let Ok(profiles) = profile_result {
-            if let Some(profile) = profiles.first() {
-                if let Some(store) = profile.store.get(&profile.default_profile_name) {
-                    let low = store.target_low.first().map(|x| x.value).unwrap_or(4.0);
-                    let high = store.target_high.first().map(|x| x.value).unwrap_or(10.0);
-                    let mmol = store.units.starts_with("mmol");
-                    if mmol {
-                        (low * 18.0, high * 18.0, true)
-                    } else {
-                        (low, high, false)
-                    }
-                } else {
-                    (72.0, 180.0, false)
-                }
-            } else {
-                (72.0, 180.0, false)
-            }
-        } else {
-            (72.0, 180.0, false)
-        };
+        let (target_low, target_high, is_mmol) = profile_result
+            .as_ref()
+            .ok()
+            .and_then(|profiles| profiles.first())
+            .and_then(|profile| profile.store.get(&profile.default_profile_name))
+            .map(resolve_profile_targets_mgdl)
+            .unwrap_or((72.0, 180.0, false));
 
         let mut sorted = sparkline_entries;
         sorted.sort_by_key(|e| e.date);
@@ -165,9 +153,9 @@ pub async fn bg(
             format!("{} h ago", duration.num_hours())
         };
 
-        let current_status = if (entry.sgv as f64) < target_low {
+        let current_status = if (entry.sgv as f32) < target_low {
             GlucoseStatus::Low
-        } else if (entry.sgv as f64) > target_high {
+        } else if (entry.sgv as f32) > target_high {
             GlucoseStatus::High
         } else {
             GlucoseStatus::InRange
@@ -197,7 +185,7 @@ pub async fn bg(
                 } else {
                     0.0
                 };
-                let sgv_mgdl = e.sgv as f64;
+                let sgv_mgdl = e.sgv as f32;
                 let status = if sgv_mgdl < target_low {
                     GlucoseStatus::Low
                 } else if sgv_mgdl > target_high {

--- a/crates/bot/src/commands/graph.rs
+++ b/crates/bot/src/commands/graph.rs
@@ -1,6 +1,7 @@
 use crate::data::{Context, Error};
 use crate::utils::duration_parser::parse_ago_duration;
 use crate::utils::sticker_assets;
+use crate::utils::targets::resolve_profile_targets_mgdl;
 use crate::utils::theme_assets;
 use bonbon::prelude::*;
 use chrono::{Duration, Utc};
@@ -103,16 +104,9 @@ pub async fn graph(
         .and_then(|p| p.first())
         .and_then(|p| p.store.get(&p.default_profile_name))
         .map(|store| {
-            let low = store.target_low.first().map(|x| x.value).unwrap_or(4.0);
-            let high = store.target_high.first().map(|x| x.value).unwrap_or(10.0);
             let tz: Tz = store.timezone.parse().unwrap_or(chrono_tz::UTC);
-            let mmol = store.units.starts_with("mmol");
-            let (low_mg, high_mg) = if mmol {
-                (low * 18.0, high * 18.0)
-            } else {
-                (low, high)
-            };
-            (low_mg as f32, high_mg as f32, tz, mmol)
+            let (low_mg, high_mg, mmol) = resolve_profile_targets_mgdl(store);
+            (low_mg, high_mg, tz, mmol)
         })
         .unwrap_or((72.0, 180.0, chrono_tz::UTC, false));
 

--- a/crates/bot/src/commands/tir.rs
+++ b/crates/bot/src/commands/tir.rs
@@ -1,4 +1,5 @@
 use crate::data::{Context, Error};
+use crate::utils::targets::resolve_profile_targets_mgdl;
 use crate::utils::theme_assets;
 use bonbon::prelude::*;
 use chrono::{Duration, Utc};
@@ -117,15 +118,8 @@ pub async fn tir(
         .and_then(|p| p.first())
         .and_then(|p| p.store.get(&p.default_profile_name))
         .map(|store| {
-            let low = store.target_low.first().map(|x| x.value).unwrap_or(4.0);
-            let high = store.target_high.first().map(|x| x.value).unwrap_or(10.0);
-            let mmol = store.units.starts_with("mmol");
-            let (low_mg, high_mg) = if mmol {
-                (low * 18.0, high * 18.0)
-            } else {
-                (low, high)
-            };
-            (low_mg as f32, high_mg as f32, mmol)
+            let (low_mg, high_mg, mmol) = resolve_profile_targets_mgdl(store);
+            (low_mg, high_mg, mmol)
         })
         .unwrap_or((72.0, 180.0, false));
 

--- a/crates/bot/src/utils/mod.rs
+++ b/crates/bot/src/utils/mod.rs
@@ -2,4 +2,5 @@ pub mod duration_parser;
 pub mod emojis;
 pub mod net;
 pub mod sticker_assets;
+pub mod targets;
 pub mod theme_assets;

--- a/crates/bot/src/utils/targets.rs
+++ b/crates/bot/src/utils/targets.rs
@@ -1,0 +1,36 @@
+use cinnamon::models::profile::ProfileConfig;
+
+const DEFAULT_LOW_MGDL: f32 = 72.0;
+const DEFAULT_HIGH_MGDL: f32 = 180.0;
+
+fn target_to_mgdl(value: Option<f64>, is_mmol: bool) -> Option<f32> {
+    let value = value?;
+
+    if !value.is_finite() || value <= 0.0 {
+        return None;
+    }
+
+    let mgdl = if is_mmol { value * 18.0 } else { value };
+
+    if !(20.0..=600.0).contains(&mgdl) {
+        return None;
+    }
+
+    Some(mgdl as f32)
+}
+
+pub fn resolve_profile_targets_mgdl(store: &ProfileConfig) -> (f32, f32, bool) {
+    let is_mmol = store.units.starts_with("mmol");
+
+    let low = target_to_mgdl(store.target_low.first().map(|x| x.value), is_mmol)
+        .unwrap_or(DEFAULT_LOW_MGDL);
+
+    let high = target_to_mgdl(store.target_high.first().map(|x| x.value), is_mmol)
+        .unwrap_or(DEFAULT_HIGH_MGDL);
+
+    if high <= low {
+        return (DEFAULT_LOW_MGDL, DEFAULT_HIGH_MGDL, is_mmol);
+    }
+
+    (low, high, is_mmol)
+}


### PR DESCRIPTION
Closes #34.

This PR Sanitizes target ranges sent from Nightscout.
Before, if NS sent a target range such as 0, or 10, Beetroot would use it blindly resulting in graphs and tir looking like you're high 24/7 due to a misconfigured NS.